### PR TITLE
Updated fixed google style guide link on readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This document draws heavily from the following guides written by smarter people than me:
 
-- https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
+- https://google.github.io/styleguide/jsguide.html
 - http://javascript.crockford.com/code.html
 - https://github.com/airbnb/javascript
 


### PR DESCRIPTION
The existing link point to
https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml

Google has updated the link to
https://google.github.io/styleguide/jsguide.html

closed #5 